### PR TITLE
Use ioutil.TempDir to generate a unique tmp dir for each test run

### DIFF
--- a/aqbanking_test.go
+++ b/aqbanking_test.go
@@ -1,6 +1,7 @@
 package aqbanking
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -14,9 +15,14 @@ func TestDefaultAQBankingInstance(t *testing.T) {
 }
 
 func TestNewAQBankingInstance(t *testing.T) {
-	defer os.RemoveAll("./tmp")
+	tmp, err := ioutil.TempDir("", "aqbanking")
+	if err != nil {
+		t.Errorf("unable to create temporary dir: %v", err)
+		return
+	}
+	defer os.RemoveAll(tmp)
 
-	aq, err := NewAQBanking("example", "./tmp")
+	aq, err := NewAQBanking("example", tmp)
 
 	if err != nil {
 		t.Fatalf("unable to create custom aqbanking instance")

--- a/user_test.go
+++ b/user_test.go
@@ -2,14 +2,20 @@ package aqbanking
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func TestRemoveUser(t *testing.T) {
-	defer os.RemoveAll("./tmp")
+	tmp, err := ioutil.TempDir("", "aqbanking")
+	if err != nil {
+		t.Errorf("unable to create temporary dir: %v", err)
+		return
+	}
+	defer os.RemoveAll(tmp)
 
-	aq, err := NewAQBanking("user tests", "./tmp")
+	aq, err := NewAQBanking("user tests", tmp)
 	if err != nil {
 		t.Fatalf("unable to create aqbanking instance: %v", err)
 	}
@@ -42,9 +48,14 @@ func TestRemoveUser(t *testing.T) {
 }
 
 func TestAddUserAndListUsers(t *testing.T) {
-	defer os.RemoveAll("./tmp")
+	tmp, err := ioutil.TempDir("", "aqbanking")
+	if err != nil {
+		t.Errorf("unable to create temporary dir: %v", err)
+		return
+	}
+	defer os.RemoveAll(tmp)
 
-	aq, err := NewAQBanking("user tests", "./tmp")
+	aq, err := NewAQBanking("user tests", tmp)
 	if err != nil {
 		t.Fatalf("unable to create aqbanking instance: %v", err)
 	}


### PR DESCRIPTION
Better safe than sorry and wiping someone's `./tmp` of "oh-so important" work. Also lets you parallelize tests easily - in theory at least.